### PR TITLE
Remove interactive from keypress-multi-event

### DIFF
--- a/keypress-multi-event.el
+++ b/keypress-multi-event.el
@@ -58,7 +58,6 @@ The optional arg FORCE-THIS-ONE is an integer index into REACTIONS.
 This function was originally written to support functions
 `home-end-home' and `home-end-end' in package `home-end.el'. See
 there for a usage example."
-  (interactive)
   (if (or executing-kbd-macro defining-kbd-macro)
     (funcall (nth 0 reactions))
    (setq keypress-multi-event--state


### PR DESCRIPTION
keypress-multi-event was an interactive command, but

   M-x keypress-multi-event

fail with 'Wrong number of arguments', probably because it should not
be called directly, but only by other command/function.